### PR TITLE
Parse voltage as little endian int16.

### DIFF
--- a/ibbq.go
+++ b/ibbq.go
@@ -254,8 +254,8 @@ func (ibbq *Ibbq) settingResultReceived() ble.NotificationHandler {
 		switch data[0] {
 		case 0x24:
 			// battery
-			currentVoltage := int(binary.BigEndian.Uint16(data[1:3]))
-			maxVoltage := int(binary.BigEndian.Uint16(data[3:5]))
+			currentVoltage := int(binary.LittleEndian.Uint16(data[1:3]))
+			maxVoltage := int(binary.LittleEndian.Uint16(data[3:5]))
 			if maxVoltage == 0 {
 				maxVoltage = 65535
 			}


### PR DESCRIPTION
Before this change, when parsing the BatteryLevels response, the
currentVoltage and maxVoltage were parsed as big endian values,
which produced strange results. Parsing them as little endian
values restored sanity, with a values that remains between 0 and
100.

These values are also documented as being little-endian int64
on https://gist.github.com/uucidl/b9c60b6d36d8080d085a8e3310621d64